### PR TITLE
Use listen for hot code reloading

### DIFF
--- a/.gems
+++ b/.gems
@@ -1,4 +1,4 @@
 sass -v 3.3.8
 haml -v 4.0.5
 clap -v 1.0.0
-rb-fsevent -v 0.9.4
+listen -v 3.0.3

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 source
 public
 *.gem
+.bundle

--- a/bin/trekky
+++ b/bin/trekky
@@ -1,13 +1,13 @@
 #!/usr/bin/env ruby
 require 'clap'
-require 'rb-fsevent'
+require 'listen'
 require_relative '../lib/trekky'
 
 source = 'source'
 target = 'public'
 daemon = false
 
-Clap.run ARGV, 
+Clap.run ARGV,
   "-s" => lambda {|s| source = s },
   "-t" => lambda {|t| target = t },
   "-d" => lambda { daemon = true },
@@ -19,16 +19,16 @@ Clap.run ARGV,
 
 trekky = Trekky.new(source)
 
-unless daemon 
+unless daemon
   trekky.render_to(target)
 else
   STDOUT.puts "-> Initial run (daemon mode)"
   trekky.render_to(target)
-  fsevent = FSEvent.new
-  # TODO: Use yielded directories to only process some changes files, and not the whole source dir. 
-  fsevent.watch(source) do 
+  # TODO: Use yielded directories to only process some changes files, and not the whole source dir.
+  listener = Listen.to(source, 'data') do |modified, added, removed|
     trekky.render_to(target)
     STDOUT.puts "-> Done processing. "
   end
-  fsevent.run
+  listener.start # not blocking
+  sleep
 end

--- a/trekky.gemspec
+++ b/trekky.gemspec
@@ -9,19 +9,19 @@ Gem::Specification.new do |s|
   s.email             = ["lucasefe@gmail.com"]
   s.homepage          = "http://github.com/lucasefe/trekky"
   s.files             = [
-                          "README.md", 
-                          "bin/trekky", 
-                          "lib/trekky.rb", 
-                          "lib/trekky/context.rb", 
-                          "lib/trekky/data.rb", 
-                          "lib/trekky/haml_source.rb", 
-                          "lib/trekky/sass_source.rb", 
-                          "lib/trekky/source.rb", 
+                          "README.md",
+                          "bin/trekky",
+                          "lib/trekky.rb",
+                          "lib/trekky/context.rb",
+                          "lib/trekky/data.rb",
+                          "lib/trekky/haml_source.rb",
+                          "lib/trekky/sass_source.rb",
+                          "lib/trekky/source.rb",
                           "lib/trekky/static_source.rb" ]
   s.license           = "MIT"
   s.executables.push('trekky')
   s.add_dependency 'clap', '~> 1.0'
   s.add_dependency 'sass', '~> 3.3'
   s.add_dependency 'haml', '~> 4.0'
-  s.add_dependency 'rb-fsevent', '~> 0.9'
+  s.add_dependency 'listen', '~> 3.0'
 end


### PR DESCRIPTION
The rb-fsevent is OS X. The listen gem features multiple adapters and supports both OS X and Linux platforms.
